### PR TITLE
SP-82: Ignore openssl vulnerability in Alpine Docker image. Fix not yet available

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Vulnerability in base Alpine image, ignore until fixed
+CVE-2023-5363
+CVE-2023-5678


### PR DESCRIPTION
Ignore `CVE-2023-5363` and `CVE-2023-5678` during Trivy vulnerability scanning